### PR TITLE
Refactoring

### DIFF
--- a/Controller/TemplateController.php
+++ b/Controller/TemplateController.php
@@ -14,12 +14,12 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CampaignChain\CoreBundle\Entity\Campaign;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
-use CampaignChain\CoreBundle\Entity\Module;
 use CampaignChain\CoreBundle\Entity\Action;
 
+/**
+ * Class TemplateController
+ * @package CampaignChain\Campaign\TemplateBundle\Controller
+ */
 class TemplateController extends Controller
 {
     const CAMPAIGN_DISPLAY_NAME = "Campaign Template";
@@ -27,26 +27,15 @@ class TemplateController extends Controller
     const MODULE_IDENTIFIER = 'campaignchain-template';
     const TRIGGER_HOOK = 'campaignchain-timespan';
 
-    public function indexAction(){
+    public function indexAction()
+    {
         // Get the campaign templates
-        $qb = $this->getDoctrine()->getEntityManager()->createQueryBuilder();
-        $qb->select('c')
-            ->from('CampaignChain\CoreBundle\Entity\Campaign', 'c')
-            ->from('CampaignChain\CoreBundle\Entity\Module', 'm')
-            ->from('CampaignChain\CoreBundle\Entity\Bundle', 'b')
-            ->where('b.name = :bundleName')
-            ->andWhere('m.identifier = :moduleIdentifier')
-            ->andWhere('m.id = c.campaignModule')
-            ->setParameter('bundleName', static::BUNDLE_NAME)
-            ->setParameter('moduleIdentifier', static::MODULE_IDENTIFIER)
-            ->orderBy('c.name', 'ASC');
-        $query = $qb->getQuery();
-        $repository_campaigns = $query->getResult();
+        $repository_campaigns = $this->getDoctrine()->getRepository('CampaignChainCoreBundle:Campaign')->getCampaignsByModule(static::MODULE_IDENTIFIER);
 
         return $this->render(
             'CampaignChainCampaignTemplateBundle::index.html.twig',
             array(
-                'page_title' => static::CAMPAIGN_DISPLAY_NAME.'s',
+                'page_title' => static::CAMPAIGN_DISPLAY_NAME . 's',
                 'repository_campaigns' => $repository_campaigns,
             ));
     }
@@ -62,54 +51,54 @@ class TemplateController extends Controller
         // All campaign templates start Jan 1st, 2012 midnight.
         $campaign->setStartDate(new \DateTime('2012-01-01 00:00:00'));
 
-        $campaignType = $this->get('campaignchain.core.form.type.campaign');
-        $campaignType->setBundleName(static::BUNDLE_NAME);
-        $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+        $campaignType = $this->getCampaignType();
 
         $form = $this->createForm($campaignType, $campaign);
 
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $repository = $this->getDoctrine()->getManager();
+            $em = $this->getDoctrine()->getManager();
 
             // Make sure that data stays intact by using transactions.
             try {
-                $repository->getConnection()->beginTransaction();
+                $em->getConnection()->beginTransaction();
 
-                $repository->persist($campaign);
+                $em->persist($campaign);
 
                 // We need the campaign ID for storing the hooks. Hence we must flush here.
-                $repository->flush();
+                $em->flush();
 
                 $hookService = $this->get('campaignchain.core.hook');
-                $campaign = $hookService->processHooks(static::BUNDLE_NAME, static::MODULE_IDENTIFIER, $campaign, $form, true);
+                $campaign = $hookService->processHooks(static::BUNDLE_NAME, static::MODULE_IDENTIFIER, $campaign, $form,
+                    true);
 
                 $hookService = $this->get('campaignchain.core.hook');
                 $campaign->setTriggerHook(
                     $hookService->getHook(static::TRIGGER_HOOK)
                 );
-                
-                $repository->flush();
 
-                $repository->getConnection()->commit();
+                $em->flush();
+
+                $em->getConnection()->commit();
             } catch (\Exception $e) {
-                $repository->getConnection()->rollback();
+                $em->getConnection()->rollback();
                 throw $e;
             }
 
-            $this->get('session')->getFlashBag()->add(
+            $this->addFlash(
                 'success',
-                'Your new campaign template <a href="'.$this->generateUrl('campaignchain_campaign_template_edit', array('id' => $campaign->getId())).'">'.$campaign->getName().'</a> was created successfully.'
+                'Your new campaign template <a href="' . $this->generateUrl('campaignchain_campaign_template_edit',
+                    array('id' => $campaign->getId())) . '">' . $campaign->getName() . '</a> was created successfully.'
             );
 
-            return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+            return $this->redirectToRoute('campaignchain_core_campaign');
         }
 
         return $this->render(
             'CampaignChainCoreBundle:Base:new.html.twig',
             array(
-                'page_title' => 'New '.static::CAMPAIGN_DISPLAY_NAME,
+                'page_title' => 'New ' . static::CAMPAIGN_DISPLAY_NAME,
                 'form' => $form->createView(),
                 'form_submit_label' => 'Save',
             ));
@@ -120,35 +109,34 @@ class TemplateController extends Controller
         $campaignService = $this->get('campaignchain.core.campaign');
         $campaign = $campaignService->getCampaign($id);
 
-        $campaignType = $this->get('campaignchain.core.form.type.campaign');
-        $campaignType->setBundleName(static::BUNDLE_NAME);
-        $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+        $campaignType = $this->getCampaignType();
 
         $form = $this->createForm($campaignType, $campaign);
 
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $repository = $this->getDoctrine()->getManager();
+            $em = $this->getDoctrine()->getManager();
 
             $hookService = $this->get('campaignchain.core.hook');
             $campaign = $hookService->processHooks(static::BUNDLE_NAME, static::MODULE_IDENTIFIER, $campaign, $form);
-            $repository->persist($campaign);
+            $em->persist($campaign);
 
-            $repository->flush();
+            $em->flush();
 
-            $this->get('session')->getFlashBag()->add(
+            $this->addFlash(
                 'success',
-                'Your campaign template <a href="'.$this->generateUrl('campaignchain_core_campaign_edit', array('id' => $campaign->getId())).'">'.$campaign->getName().'</a> was edited successfully.'
+                'Your campaign template <a href="' . $this->generateUrl('campaignchain_core_campaign_edit',
+                    array('id' => $campaign->getId())) . '">' . $campaign->getName() . '</a> was edited successfully.'
             );
 
-            return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+            return $this->redirectToRoute('campaignchain_core_campaign');
         }
 
         return $this->render(
             'CampaignChainCampaignTemplateBundle::edit.html.twig',
             array(
-                'page_title' => 'Edit '.static::CAMPAIGN_DISPLAY_NAME,
+                'page_title' => 'Edit ' . static::CAMPAIGN_DISPLAY_NAME,
                 'page_secondary_title' => $campaign->getName(),
                 'form' => $form->createView(),
                 'form_submit_label' => 'Save',
@@ -164,9 +152,7 @@ class TemplateController extends Controller
         $campaignService = $this->get('campaignchain.core.campaign');
         $campaign = $campaignService->getCampaign($id);
 
-        $campaignType = $this->get('campaignchain.core.form.type.campaign');
-        $campaignType->setBundleName(static::BUNDLE_NAME);
-        $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+        $campaignType = $this->getCampaignType();
         $campaignType->setView('default');
 
         $form = $this->createForm($campaignType, $campaign);
@@ -174,7 +160,7 @@ class TemplateController extends Controller
         return $this->render(
             'CampaignChainCoreBundle:Campaign:edit_modal.html.twig',
             array(
-                'page_title' => 'Edit '.static::CAMPAIGN_DISPLAY_NAME,
+                'page_title' => 'Edit ' . static::CAMPAIGN_DISPLAY_NAME,
                 'form' => $form->createView(),
                 'campaign' => $campaign,
                 'form_submit_label' => 'Save',
@@ -194,24 +180,21 @@ class TemplateController extends Controller
         $campaign->setName($data['name']);
         $campaign->setTimezone($data['timezone']);
 
-        $repository = $this->getDoctrine()->getManager();
-        $repository->persist($campaign);
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($campaign);
 
         $hookService = $this->get('campaignchain.core.hook');
         $hookService->processHooks(static::BUNDLE_NAME, static::MODULE_IDENTIFIER, $campaign, $data);
 
-        $repository->flush();
+        $em->flush();
 
         $responseData['start_date'] = $campaign->getStartDate()->format(\DateTime::ISO8601);
         $responseData['end_date'] = $campaign->getEndDate()->format(\DateTime::ISO8601);
 
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
-        $response = new Response($serializer->serialize($responseData, 'json'));
-        return $response->setStatusCode(Response::HTTP_OK);
+        return new Response($serializer->serialize($responseData, 'json'));
     }
 
     public function copyAction(Request $request, $id)
@@ -220,14 +203,12 @@ class TemplateController extends Controller
         $fromCampaign = $campaignService->getCampaign($id);
         $campaignURI = $campaignService->getCampaignURI($fromCampaign);
 
-        switch($campaignURI){
+        switch ($campaignURI) {
             case 'campaignchain/campaign-template/campaignchain-template':
                 $toCampaign = clone $fromCampaign;
-                $toCampaign->setName($fromCampaign->getName().' (copied)');
+                $toCampaign->setName($fromCampaign->getName() . ' (copied)');
 
-                $campaignType = $this->get('campaignchain.core.form.type.campaign');
-                $campaignType->setBundleName(static::BUNDLE_NAME);
-                $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+                $campaignType = $this->getCampaignType();
                 $campaignType->setHooksOptions(
                     array(
                         'campaignchain-timespan' => array(
@@ -245,21 +226,21 @@ class TemplateController extends Controller
                     $clonedCampaign = $copyService->template2Template(
                         $fromCampaign, null, $toCampaign->getName());
 
-                    $this->get('session')->getFlashBag()->add(
+                    $this->addFlash(
                         'success',
-                        'The '.static::CAMPAIGN_DISPLAY_NAME.' <a href="'.$this->generateUrl(
+                        'The ' . static::CAMPAIGN_DISPLAY_NAME . ' <a href="' . $this->generateUrl(
                             'campaignchain_core_campaign_edit',
-                            array('id' => $clonedCampaign->getId())).'">'.
-                        $clonedCampaign->getName().'</a> was copied successfully.'
+                            array('id' => $clonedCampaign->getId())) . '">' .
+                        $clonedCampaign->getName() . '</a> was copied successfully.'
                     );
 
-                    return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+                    return $this->redirectToRoute('campaignchain_core_campaign');
                 }
 
                 return $this->render(
                     'CampaignChainCoreBundle:Base:new.html.twig',
                     array(
-                        'page_title' => 'Copy '.static::CAMPAIGN_DISPLAY_NAME,
+                        'page_title' => 'Copy ' . static::CAMPAIGN_DISPLAY_NAME,
                         'form' => $form->createView(),
                     ));
                 break;
@@ -267,10 +248,8 @@ class TemplateController extends Controller
                 $scheduledCampaign = $fromCampaign;
                 $campaignTemplate = clone $scheduledCampaign;
 
-                $campaignTemplate->setName($scheduledCampaign->getName().' (copied)');
-                $campaignType = $this->get('campaignchain.core.form.type.campaign');
-                $campaignType->setBundleName(static::BUNDLE_NAME);
-                $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+                $campaignTemplate->setName($scheduledCampaign->getName() . ' (copied)');
+                $campaignType = $this->getCampaignType();
                 $campaignType->setHooksOptions(
                     array(
                         'campaignchain-timespan' => array(
@@ -288,22 +267,31 @@ class TemplateController extends Controller
                     $clonedCampaign = $copyService->scheduled2Template(
                         $campaignTemplate, null, $campaignTemplate->getName());
 
-                    $this->get('session')->getFlashBag()->add(
+                    $this->addFlash(
                         'success',
-                        'The campaign template <a href="'.$this->generateUrl('campaignchain_core_campaign_edit', array('id' => $clonedCampaign->getId())).'">'.$clonedCampaign->getName().'</a> was copied successfully.'
+                        'The campaign template <a href="' . $this->generateUrl('campaignchain_core_campaign_edit',
+                            array('id' => $clonedCampaign->getId())) . '">' . $clonedCampaign->getName() . '</a> was copied successfully.'
                     );
 
-                    return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+                    return $this->redirectToRoute('campaignchain_core_campaign');
                 }
 
                 return $this->render(
                     'CampaignChainCoreBundle:Base:new.html.twig',
                     array(
-                        'page_title' => 'Copy Scheduled Campaign as '.static::CAMPAIGN_DISPLAY_NAME,
+                        'page_title' => 'Copy Scheduled Campaign as ' . static::CAMPAIGN_DISPLAY_NAME,
                         'form' => $form->createView(),
                     ));
 
                 break;
         }
+    }
+
+    protected function getCampaignType() {
+        $campaignType = $this->get('campaignchain.core.form.type.campaign');
+        $campaignType->setBundleName(static::BUNDLE_NAME);
+        $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+
+        return $campaignType;
     }
 }

--- a/Controller/TemplateController.php
+++ b/Controller/TemplateController.php
@@ -31,7 +31,7 @@ class TemplateController extends Controller
     public function indexAction()
     {
         // Get the campaign templates
-        $repository_campaigns = $this->getDoctrine()->getRepository('CampaignChainCoreBundle:Campaign')->getCampaignsByModule(static::MODULE_IDENTIFIER);
+        $repository_campaigns = $this->getDoctrine()->getRepository('CampaignChainCoreBundle:Campaign')->getCampaignsByModule(static::MODULE_IDENTIFIER, static::BUNDLE_NAME);
 
         return $this->render(
             'CampaignChainCampaignTemplateBundle::index.html.twig',


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
